### PR TITLE
Match look of Posts on Homepage to Single Template

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@ custom_css_class: single
 
     {% if page.link_url %}
       <h1 class="p-name">
-        <a class="u-bookmark-of" href="{{ page.link_url }}">{{ page.title | widont }}</a>
+        <a class="u-bookmark-of" href="{{ page.link_url }}">{{ page.title | widont }}</a>&nbsp;<span class="link-arrow">&rarr;</span>
       </h1>
     {% else %}
       <h1 class="p-name">{{ page.title | widont }}</h1>

--- a/assets/stylesheets/_layout/_maincontent.scss
+++ b/assets/stylesheets/_layout/_maincontent.scss
@@ -300,6 +300,15 @@
       text-decoration: underline solid $link-color;
     }
   }
+
+  .link-arrow {
+    font-family: sans-serif;
+    font-size: 0.75em;
+    vertical-align: middle;
+    color: lighten($light-text-color, 20%);
+    position: relative;
+    top: -2px;
+  }
 }
 
 // Footnotes ---------------------

--- a/assets/stylesheets/_layout/_maincontent.scss
+++ b/assets/stylesheets/_layout/_maincontent.scss
@@ -21,41 +21,13 @@
   }
 }
 
-.post__permalink {
-  color: $light-text-color;
-  font-weight: normal;
-  text-decoration: none;
-  &:hover,
-  &:focus {
-    color: $link-color;
-    text-decoration: none;
-  }
-
-  .date__hash {
-    color: $primary-color;
-  }
-}
-
-.small-author {
-  color: $light-text-color;
-  font-family: $font-code;
-  font-size: $ratio-2;
-
-  @media #{$medium-up} {
-    &:after {
-      content: '/';
-      margin-left: 0.6rem;
-      margin-right: 0.6rem;
+.posts {
+  .post__date {
+    a {
+      font-weight: normal;
+      text-decoration: none;
+      color: $light-text-color;
     }
-  }
-
-  img {
-    width: 26px;
-    border-radius: 3px;
-  }
-
-  span {
-    line-height: 1.3;
   }
 }
 
@@ -166,25 +138,6 @@
 
 .author__picture {
   border-radius: 5px;
-}
-
-.author__credit {
-  align-items: center;
-  color: $light-text-color;
-  display: grid;
-  font-family: $font-code;
-  grid-column-gap: 0.6rem;
-  grid-template-columns: 30px auto;
-  margin-bottom: 1.6rem;
-
-  p {
-    font-size: $ratio-2;
-  }
-
-  .author__picture {
-    width: 30px;
-    border-radius: 3px;
-  }
 }
 
 // Format Post -------------------
@@ -345,13 +298,6 @@
     &:focus,
     &:hover {
       text-decoration: underline solid $link-color;
-    }
-  }
-
-  .posts & {
-    .post__meta {
-      margin-bottom: 0.8rem;
-      margin-top: 0;
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -12,29 +12,30 @@ excerpt: Bright Pixels is a web-column about comics, Star Wars, Apple, technolog
   {% for post in filteredPosts limit: 20 %}
     <article class="posts__post p-body format-{% if post.link_url %}link{% else %}post{% endif %} h-entry">
 
-      {% if post.link_url %}
-        <header class="post__header">
-          <div class="post__meta">
-            <a class="post__permalink u-url" href="{{ post.url}}" title="Permalink to {{ post.title }}"><time class="dt-published" datetime="{{ post.date | date_to_xmlschema }}"><span class="date__hash u-url">#</span>&ensp;{{ post.date | date: "%b %d" }}</time></a>
-          </div>
+      <header class="post__header">
+        <span class="post__category"><a class="p-category" href="/{{ post.categories[0] | slugify }}" title="More posts about {{ post.categories[0] }}">{{ post.categories[0] }}</a></span>
+
+        {% if post.link_url %}
           <h1 class="p-name">
             <a class="u-bookmark-of" href="{{ post.link_url }}">{{ post.title | widont }}</a>
           </h1>
-        </header>
-      {% else %}
-        <header class="post__header">
-          <h1 class="p-name">
-            <a class="u-url" href="{{ post.url }}">{{ post.title | widont }}</a>
-          </h1>
+        {% else %}
+          <h1 class="p-name"><a href="{{ post.url }}" title="Permalink for {{ post.title }}">{{ post.title | widont }}</a></h1>
           {% if post.subtitle %}
-          <h2 class="post__subtitle">{{ post.subtitle | widont }}</h2>
-          {% endif %}
+            <h2 class="post__subtitle">{{ post.subtitle | widont }}</h2>
+          {% endif %} 
+        {% endif %}
 
-          {% if post.review.type %}
-            {% include_cached star-rating.html rating=post.review.rating %}
-          {% endif %}
-        </header>
-      {% endif %}
+        <!-- Post Meta -->
+        {% assign author = site.data.authors[post.author] %}
+        <div class="post__meta">
+          <span class="post__author"><a class="p-author h-card" href="/authors/{{ author.author_path }}" title="View more posts written by {{ author.display_name }}">{{ author.display_name }}{% if author.gravatar %}<img class="u-photo" src="//gravatar.com/avatar/{{ author.gravatar}}?s=200" alt="{{ author.display_name }}" style="display: none;" />{% else %}<img src="{{ site.url }}/uploads/authors/{{ author.author_path }}.jpg" class="u-photo" alt="{{ author.display_name }}" style="display: none;"/>{% endif %}</a></span>&emsp;<span class="post__date"><time class="dt-published" datetime="{{ post.date | date_to_xmlschema }}"><a href="{{ post.url | prepend: site.url }}" class="u-url">{{ post.date | date: "%b %d, %Y" }}</a></time></span>
+        </div>
+
+        {% if post.review.type %}
+          {% include_cached star-rating.html rating=post.review.rating %}
+        {% endif %}
+      </header>
     
       <div class="e-content">{{ post.content | widont | caps }}</div>
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ excerpt: Bright Pixels is a web-column about comics, Star Wars, Apple, technolog
 
         {% if post.link_url %}
           <h1 class="p-name">
-            <a class="u-bookmark-of" href="{{ post.link_url }}">{{ post.title | widont }}</a>
+            <a class="u-bookmark-of" href="{{ post.link_url }}">{{ post.title | widont }}</a>&nbsp;<span class="link-arrow">&rarr;</span>
           </h1>
         {% else %}
           <h1 class="p-name"><a href="{{ post.url }}" title="Permalink for {{ post.title }}">{{ post.title | widont }}</a></h1>


### PR DESCRIPTION
#### Purpose

Same info is displayed on the homepage now. Category, author, and date.

#### Screenshots

<img width="1552" alt="screenshot 2019-02-10 00 58 47" src="https://user-images.githubusercontent.com/1326249/52530730-09749b00-2ccf-11e9-8222-c7abe1cf38e8.png">

 :coffee:
